### PR TITLE
feat: setup season details dialog w/ episode card

### DIFF
--- a/src/app/app/movies/[id]/components/movie-details.tsx
+++ b/src/app/app/movies/[id]/components/movie-details.tsx
@@ -35,6 +35,8 @@ export const MovieDetails = async ({ id }: MovieBannerProps) => {
     belongs_to_collection: belongsToCollection,
     revenue,
     budget,
+    vote_average: voteAverage,
+    vote_count: voteCount,
   } = await TMDB.movies.details(id)
 
   return (
@@ -48,7 +50,19 @@ export const MovieDetails = async ({ id }: MovieBannerProps) => {
           </aside>
 
           <article className="flex w-2/3 flex-col gap-2">
-            <div>
+            <div className="flex gap-1">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge>{voteAverage.toFixed(1)}</Badge>
+                  </TooltipTrigger>
+
+                  <TooltipContent>
+                    <p>{voteCount} votes</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+
               <Badge variant="outline">
                 {format(new Date(releaseDate), 'PPP')}
               </Badge>
@@ -66,7 +80,7 @@ export const MovieDetails = async ({ id }: MovieBannerProps) => {
 
             <p className="text-sm text-muted-foreground">{overview}</p>
 
-            <div className="flex flex-wrap gap-1">
+            <div className="mt-2 flex flex-wrap gap-1">
               {genres.map((genre) => {
                 return (
                   <Badge key={genre.id} variant="outline">
@@ -80,7 +94,7 @@ export const MovieDetails = async ({ id }: MovieBannerProps) => {
 
             <div className="flex flex-wrap gap-1">
               {budget > 0 && (
-                <Badge variant="secondary">
+                <Badge variant="outline">
                   Budget: {formatCurrency(budget)}
                 </Badge>
               )}
@@ -89,7 +103,7 @@ export const MovieDetails = async ({ id }: MovieBannerProps) => {
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger>
-                      <Badge variant="secondary">
+                      <Badge variant="outline">
                         Revenue: {formatCurrency(revenue)}
                       </Badge>
                     </TooltipTrigger>

--- a/src/app/app/tv-shows/[id]/components/tv-show-details-seasons.tsx
+++ b/src/app/app/tv-shows/[id]/components/tv-show-details-seasons.tsx
@@ -1,9 +1,18 @@
 import { Poster } from '@/app/app/components/poster'
 import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { tmdbImage } from '@/utils/tmdb/image'
 import { StarFilledIcon } from '@radix-ui/react-icons'
 import { format } from 'date-fns'
 import { Season as TmdbSeason } from 'tmdb-ts'
+import { TvShowSeasonDetails } from './tv-show-season-details'
 
 type Season = TmdbSeason & {
   vote_average?: number
@@ -11,59 +20,79 @@ type Season = TmdbSeason & {
 
 type TvShowDetailsSeasonsProps = {
   seasons: Season[]
+  tvShowID: number
 }
 
-type TvShowDetailsSeasonProps = { season: Season }
+type TvShowDetailsSeasonProps = { season: Season; tvShowID: number }
 
-const TvShowDetailsSeason = ({ season }: TvShowDetailsSeasonProps) => {
+const TvShowDetailsSeason = ({
+  season,
+  tvShowID,
+}: TvShowDetailsSeasonProps) => {
   const {
     poster_path: poster,
     name,
     overview,
     episode_count: episodeCount,
     air_date: airDate,
-    vote_average: vote,
+    vote_average: voteAverage,
+    season_number: seasonNumber,
   } = season
 
   return (
-    <div className="group flex cursor-pointer space-x-4">
-      <div className="w-1/5">
-        <Poster url={tmdbImage(poster)} alt={name} />
-      </div>
+    <Dialog>
+      <DialogTrigger asChild>
+        <div className="group flex cursor-pointer space-x-4">
+          <div className="w-1/5">
+            <Poster url={tmdbImage(poster)} alt={name} />
+          </div>
 
-      <div className="w-4/5 space-y-2">
-        <div className="space-y-1">
-          <h6 className="underline-offset-1.5 text-lg font-bold group-hover:underline">
-            {name}
-          </h6>
+          <div className="w-4/5 space-y-2">
+            <div className="space-y-1">
+              <h6 className="underline-offset-1.5 text-lg font-bold group-hover:underline">
+                {name}
+              </h6>
 
-          <div className="flex flex-wrap gap-1">
-            <Badge>
-              <StarFilledIcon width={12} height={12} className="mr-1" />
-              {vote}
-            </Badge>
+              <div className="flex flex-wrap gap-1">
+                <Badge>{voteAverage?.toFixed(1)}</Badge>
 
-            <Badge variant="outline">
-              {format(new Date(airDate), 'MMM, yyyy')}
-            </Badge>
+                <Badge variant="outline">
+                  {format(new Date(airDate), 'MMM, yyyy')}
+                </Badge>
 
-            <Badge variant="outline">{episodeCount} episodes</Badge>
+                <Badge variant="outline">{episodeCount} episodes</Badge>
+              </div>
+            </div>
+
+            <p className="text-sm text-muted-foreground">{overview}</p>
           </div>
         </div>
+      </DialogTrigger>
 
-        <p className="text-sm text-muted-foreground">{overview}</p>
-      </div>
-    </div>
+      <DialogContent className="max-h-[75vh] overflow-y-auto sm:max-w-[978px]">
+        <DialogHeader className="text-start">
+          <DialogTitle>{name}</DialogTitle>
+          <DialogDescription>{overview}</DialogDescription>
+        </DialogHeader>
+
+        <TvShowSeasonDetails seasonNumber={seasonNumber} tvShowID={tvShowID} />
+      </DialogContent>
+    </Dialog>
   )
 }
 
 export const TvShowDetailsSeasons = ({
   seasons,
+  tvShowID,
 }: TvShowDetailsSeasonsProps) => {
   return (
     <div className="space-y-4">
       {seasons.map((season) => (
-        <TvShowDetailsSeason season={season} key={season.id} />
+        <TvShowDetailsSeason
+          season={season}
+          key={season.id}
+          tvShowID={tvShowID}
+        />
       ))}
     </div>
   )

--- a/src/app/app/tv-shows/[id]/components/tv-show-details.tsx
+++ b/src/app/app/tv-shows/[id]/components/tv-show-details.tsx
@@ -31,7 +31,7 @@ export const TvShowsDetails = async ({ id }: TvShowsDetailsProps) => {
           <div className="w-2/3"></div>
         </main>
 
-        <TvShowDetailsSeasons seasons={seasons} />
+        <TvShowDetailsSeasons seasons={seasons} tvShowID={id} />
       </div>
     </div>
   )

--- a/src/app/app/tv-shows/[id]/components/tv-show-season-details.tsx
+++ b/src/app/app/tv-shows/[id]/components/tv-show-season-details.tsx
@@ -1,0 +1,25 @@
+import { TMDB } from '@/services/TMDB'
+import { TvShowEpisodeCard } from './tv-show-season-episode-card'
+
+type TvShowSeasonDetailsProps = {
+  tvShowID: number
+  seasonNumber: number
+}
+
+export const TvShowSeasonDetails = async ({
+  tvShowID,
+  seasonNumber,
+}: TvShowSeasonDetailsProps) => {
+  const { episodes } = await TMDB.tvSeasons.details({
+    tvShowID,
+    seasonNumber,
+  })
+
+  return (
+    <div className="mt-2 grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2 md:grid-cols-3">
+      {episodes.map((episode) => (
+        <TvShowEpisodeCard episode={episode} key={episode.id} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/app/tv-shows/[id]/components/tv-show-season-episode-card.tsx
+++ b/src/app/app/tv-shows/[id]/components/tv-show-season-episode-card.tsx
@@ -1,0 +1,57 @@
+import { Badge } from '@/components/ui/badge'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { tmdbImage } from '@/utils/tmdb/image'
+import Image from 'next/image'
+import { Episode } from 'tmdb-ts'
+
+type TvShowEpisodeCardProps = {
+  episode: Episode
+}
+
+export const TvShowEpisodeCard = ({ episode }: TvShowEpisodeCardProps) => {
+  const {
+    name,
+    still_path: path,
+    overview,
+    vote_average: voteAverage,
+    vote_count: voteCount,
+  } = episode
+
+  return (
+    <div className="space-y-2">
+      <div className="relative aspect-video w-full overflow-hidden rounded-md border">
+        <Image
+          src={tmdbImage(path, 'w500')}
+          alt={name}
+          className="object-cover"
+          loading="lazy"
+          fill
+        />
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex items-start justify-between">
+          <span className="">{name}</span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge variant="outline">{voteAverage.toFixed(1)}</Badge>
+              </TooltipTrigger>
+
+              <TooltipContent>
+                <p>{voteCount} votes</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
+        <p className="text-xs text-muted-foreground">{overview}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/movie-card.tsx
+++ b/src/components/movie-card.tsx
@@ -2,13 +2,28 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Movie, Recommendation } from 'tmdb-ts'
 import { Skeleton } from './ui/skeleton'
+import { Badge } from './ui/badge'
+import { tmdbImage } from '@/utils/tmdb/image'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip'
 
 type MovieCardProps = {
   movie: Movie | Recommendation
 }
 
 export const MovieCard = ({ movie }: MovieCardProps) => {
-  const { title, backdrop_path: backdrop, overview, id } = movie
+  const {
+    title,
+    backdrop_path: backdrop,
+    overview,
+    id,
+    vote_average: voteAverage,
+    vote_count: voteCount,
+  } = movie
 
   if (!backdrop) return <></>
 
@@ -22,14 +37,28 @@ export const MovieCard = ({ movie }: MovieCardProps) => {
         <Image
           fill
           className="object-cover"
-          src={`https://image.tmdb.org/t/p/original/${backdrop}`}
+          src={tmdbImage(backdrop, 'w500')}
           alt={title}
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
         />
       </div>
 
-      <div>
-        <span className="">{title}</span>
+      <div className="space-y-1">
+        <div className="flex items-start justify-between">
+          <span className="">{title}</span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <Badge variant="outline">{voteAverage.toFixed(1)}</Badge>
+              </TooltipTrigger>
+
+              <TooltipContent>
+                <p>{voteCount} votes</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
         <p className="line-clamp-2 text-xs text-muted-foreground">{overview}</p>
       </div>
     </Link>

--- a/src/utils/tmdb/image.ts
+++ b/src/utils/tmdb/image.ts
@@ -1,2 +1,4 @@
-export const tmdbImage = (path: string, type = 'original') =>
-  `https://image.tmdb.org/t/p/${type}/${path}`
+export const tmdbImage = (
+  path: string,
+  type: 'original' | 'w500' = 'original',
+) => `https://image.tmdb.org/t/p/${type}/${path}`


### PR DESCRIPTION
This pull request includes the season details modal on the details page of a tv series, with the episodes and their respective information (title, overview and vote count/vote average). 

![image](https://github.com/status-451/tmdb-front-end/assets/70612836/4154edcf-0d58-44fa-8822-08ddbe0ebe06)
![image](https://github.com/status-451/tmdb-front-end/assets/70612836/6d3be455-ae7e-487d-98b5-3ff387724da3)

In **addition** to the inclusion and padronization of vote avg by the project, with a tooltip informing with the vote count, just to increase the user experience ✨✨✨

| Episode card | Movie card |  Movie details | 
|---|---|---|
| ![image](https://github.com/status-451/tmdb-front-end/assets/70612836/578164bc-ca68-41f3-8f21-757e546483a2) | ![image](https://github.com/status-451/tmdb-front-end/assets/70612836/8c3c5d2f-9a67-4f4f-95c9-4be8019f0724) | ![image](https://github.com/status-451/tmdb-front-end/assets/70612836/bc6567eb-0ff8-475c-a695-b167e6e9d31a) |


